### PR TITLE
fix: ignore invalid json responses

### DIFF
--- a/lib/util/shieldsIo.js
+++ b/lib/util/shieldsIo.js
@@ -61,6 +61,14 @@ function request(url, options) {
         const match = json.value.match(/^(\d+)%$/);
 
         return match ? Number(match[1]) / 100 : null;
+    })
+    .catch((err) => {
+        // Swallow ParseErrors (i.e. invalid json payloads, but valid responses) and return null
+        if (err instanceof got.ParseError) {
+            return null;
+        }
+
+        throw err;
     });
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ afterEach(() => {
     nock.cleanAll();
 });
 
-it('should return null if repository is not supported or if the URL is malformed', async () => {
+it('should return null if repository is not supported or if the URL is malformed or response is not json', async () => {
     nock.disableNetConnect();
 
     let promise = fetchCoverage('git@foo.com:user/project.git');
@@ -18,6 +18,16 @@ it('should return null if repository is not supported or if the URL is malformed
     expect(coverage).toBe(null);
 
     promise = fetchCoverage('git://github.com/balderdashy/waterline-%s.git');
+    coverage = await promise;
+
+    expect(promise instanceof Promise).toBe(true);
+    expect(coverage).toBe(null);
+
+    nock('https://img.shields.io')
+    .get('/codecov/c/github/user/project.json')
+    .reply(200, '<this is not json>');
+
+    promise = fetchCoverage('git@github.com:user/project.git', { services: ['codecov'] });
     coverage = await promise;
 
     expect(promise instanceof Promise).toBe(true);


### PR DESCRIPTION
We have seen occasional responses for codecov badges returning svg even though we've requested json, this is intended to ignore non-json responses and move on anyway. I chose to return `null` since that's what is currently being done for non-string responses, which this is the same class of failure as.